### PR TITLE
Fix formatting of plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -570,13 +570,12 @@
       		"min_version": "4.2.0",
 		"variant": "both"
 	},
-	"repeat_it":{
+	"repeat_it": {
 		"title": "Repeat It",
-        "author": "Ocraftyone",
-        "icon": "content_copy",
-        "description":
-            "Allows you to repeat shapes with a translation applied to each new object",
-        "version": "0.0.1",
-        "variant": "both"
+        	"author": "Ocraftyone",
+       		"icon": "content_copy",
+        	"description": "Allows you to repeat shapes with a translation applied to each new object",
+        	"version": "0.0.1",
+        	"variant": "both"
 	}
 }


### PR DESCRIPTION
Hi, I just saw your plugin. Looks cool, but I think the plugin's entry in the plugins.json file was weirdly formatted when compared to the rest of the plugins. Just to avoid trouble when the plugin gets merged, I decided to fix it.